### PR TITLE
Reduce maxcitenames to 1

### DIFF
--- a/LNI.bbx
+++ b/LNI.bbx
@@ -34,7 +34,7 @@
   giveninits    = true,
   useprefix     = false,
   maxbibnames   = 99,
-  maxcitenames  = 3,
+  maxcitenames  = 1,
   eprint        = true,
   url           = true,
   doi           = false,


### PR DESCRIPTION
I had the issue that at `\citeauthor{ABC01}` the authors were separated by `;`. I want to have following:

 * 3 authors: LN1 et al.
 * 2 authors: LN1 and LN2
 * 1 author: LN

(LN = last name)

Google found http://tex.stackexchange.com/questions/37689/how-to-personalize-citeauthor-command, I also checked the documentation, but searching for `citeauthor` did result in that `labelname` is used...

I assume that my wish is not easily implementable, thus I propose this quick fix.