### PR TITLE
[WIP] Do not show () if not editor exists

### DIFF
--- a/LNI-examples.bib
+++ b/LNI-examples.bib
@@ -7,6 +7,21 @@
   crossref = {Gl01},
 }
 
+@InProceedings{Mustermann2015,
+  author    = {Max Mustermann},
+  title     = {Mustertitel},
+  booktitle = {Musterkonferenz},
+  editor    = {Eva Musterfrau},
+  year      = {2015},
+}
+
+@InProceedings{Mustermann2016,
+  author    = {Max Mustermann},
+  title     = {Mustertitel},
+  booktitle = {Musterkonferenz},
+  year      = {2016},
+}
+
 @InBook{Az09,
   pages    = {135-162},
   title    = {Die Fußnote in LNI-Bänden},

--- a/LNI.bbx
+++ b/LNI.bbx
@@ -105,7 +105,7 @@
 \newbibmacro*{in+editor+maintitle/booktitle}{%
   \printtext{\bibstring{in}}%
   \setunit{\addspace}%
-  \printtext[parens]{\usebibmacro{editor+others}}%
+  \iffieldundef{editor}{}{\printtext[parens]{\usebibmacro{editor+others}}}%
   \setunit{\nametitledelim}\newblock
   \usebibmacro{maintitle+booktitle}}
 

--- a/LNI.bbx
+++ b/LNI.bbx
@@ -105,7 +105,10 @@
 \newbibmacro*{in+editor+maintitle/booktitle}{%
   \printtext{\bibstring{in}}%
   \setunit{\addspace}%
-  \iffieldundef{editor}{}{\printtext[parens]{\usebibmacro{editor+others}}}%
+  \ifnameundef{editor}
+    {}
+    {\printtext[parens]{%
+       \usebibmacro{editor+others}}}%
   \setunit{\nametitledelim}\newblock
   \usebibmacro{maintitle+booktitle}}
 


### PR DESCRIPTION
Current state (v0.2):

```
[Mu15] Mustermann, M.: Mustertitel. In (Musterfrau, E., Hrsg.): Musterkonferenz, 2015.
[Mu16] Mustermann, M.: Mustertitel. In (): Musterkonferenz, 2016.
```

Desired state:

```
[Mu15] Mustermann, M.: Mustertitel. In (Musterfrau, E., Hrsg.): Musterkonferenz, 2015.
[Mu16] Mustermann, M.: Mustertitel. In: Musterkonferenz, 2016.
```

With this PR:


```
[Mu15] Mustermann, M.: Mustertitel. In: Musterkonferenz, 2015.
[Mu16] Mustermann, M.: Mustertitel. In: Musterkonferenz, 2016.
```

I have no clue, why `\iffieldundef` always returns true even though an editor was given.