### PR TITLE
Improve InCollection examples

### DIFF
--- a/LNI-examples.bib
+++ b/LNI-examples.bib
@@ -115,14 +115,14 @@
 }
 
 @Proceedings{Ra03,
-  editor    = {Rauterberg, Matthias and Menozzi, Marino and Wesson, Janet},
-  title     = {Human-computer Interaction},
-  subtitle  = {{INTERACT} '03; {IFIP TC13} {International} Conference on Human-Computer Interaction},
-  year      = {2003},
-  month     = 9,
-  publisher = {IOS Press},
-  address   = {Amsterdam},
-  langid    = {english},
+  editor     = {Rauterberg, Matthias and Menozzi, Marino and Wesson, Janet},
+  title      = {Human-computer Interaction},
+  eventtitle = {{INTERACT} '03; {IFIP TC13} {International} Conference on Human-Computer Interaction},
+  year       = {2003},
+  publisher  = {IOS Press},
+  location   = {Amsterdam},
+  langid     = {english},
+  eventdate = {2003-09-01/2003-09-05},
   venue     = {Zurich, Switzerland},
 }
 

--- a/LNI-examples.bib
+++ b/LNI-examples.bib
@@ -29,12 +29,10 @@
   crossref = {Gl09},
 }
 
-@InCollection{Qu03,
+@InProceedings{Qu03,
   author   = {Quan, Dennis and Bakshi, Karun and Huynh, David and Karger, David R.},
   title    = {User Interfaces for Supporting Multiple Categorization},
   pages    = {228-235},
-  url      = {http://haystack.csail.mit.edu/papers/interact2003-multicat.pdf},
-  urldate  = {2016-07-02},
   crossref = {Ra03},
   langid   = {english},
 }
@@ -116,11 +114,12 @@
   venue     = {New York},
 }
 
-@Collection{Ra03,
+@Proceedings{Ra03,
   editor    = {Rauterberg, Matthias and Menozzi, Marino and Wesson, Janet},
   title     = {Human-computer Interaction},
+  subtitle  = {{INTERACT} '03; {IFIP TC13} {International} Conference on Human-Computer Interaction},
   year      = {2003},
-  subtitle  = {{INTERACT} '03; {IFIP TC13} {International} Conference on Human-Computer Interaction, 1\textsuperscript{st}–5\textsuperscript{th} {September} 2003, {Zurich}, {Switzerland}},
+  month     = 9,
   publisher = {IOS Press},
   address   = {Amsterdam},
   langid    = {english},
@@ -144,6 +143,31 @@
   howpublished = {Statistics Worldwide},
   year         = {2014},
 }
+
+@InCollection{BinzBKL14,
+  author    = {Tobias Binz and
+               Uwe Breitenb{\"{u}}cher and
+               Oliver Kopp and
+               Frank Leymann},
+  title     = {{TOSCA:} Portable Automated Deployment and Management of Cloud Applications},
+  pages     = {527--549},
+  crossref  = {aws2014},
+  doi       = {10.1007/978-1-4614-7535-4_22},
+  langid    = {english},
+}
+
+@Collection{aws2014,
+  editor    = {Athman Bouguettaya and
+               Quan Z. Sheng and
+               Florian Daniel},
+  title     = {Advanced Web Services},
+  publisher = {Springer},
+  year      = {2014},
+  doi       = {10.1007/978-1-4614-7535-4},
+  isbn      = {978-1-4614-7534-7},
+  langid    = {english},
+}
+
 
 @Comment{jabref-meta: databaseType:biblatex;}
 


### PR DESCRIPTION
While trying out the new InCollection entries, I had a short chat with @georgd. - This is my proposal to update the .bib.

The thing to discuss is the `url` and `urldate` fields. I like to have urls in the bib to be able to download the PDF. However, in publications, the URL is only printed for online resources, not for papers. Since it might happen that an article is not yet published, so one needs the possibility to state an URL. Therefore, I voted for not removing support for `url` and just removing the `url` entry in the bib file.
